### PR TITLE
Add rescan command

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -249,6 +249,9 @@ Database Commands
 
    With :option:`--wait`, mpc waits until MPD has finished the update.
 
+:command:`rescan [\-\-wait] [<path>]` - Like update, but also rescans
+   unmodified files.
+
 
 Sticker Commands
 ^^^^^^^^^^^^^^^^^

--- a/src/command.c
+++ b/src/command.c
@@ -406,8 +406,8 @@ cmd_listall(int argc, char **argv, struct mpd_connection *conn)
 	return 0;
 }
 
-int
-cmd_update(int argc, char **argv, struct mpd_connection *conn)
+static int
+update_db(int argc, char **argv, struct mpd_connection *conn, bool rescan)
 {
 	if (contains_absolute_path(argc, argv) && !path_prepare(conn))
 		printErrorAndExit(conn);
@@ -429,7 +429,11 @@ cmd_update(int argc, char **argv, struct mpd_connection *conn)
 		if (relative_path != NULL)
 			path = relative_path;
 
-		mpd_send_update(conn, path);
+		if (rescan)
+			mpd_send_rescan(conn, path);
+		else
+			mpd_send_update(conn, path);
+
 		free(tmp);
 	} while (++i < argc && (update = charset_to_utf8(argv[i])) != NULL);
 
@@ -471,6 +475,18 @@ cmd_update(int argc, char **argv, struct mpd_connection *conn)
 	}
 
 	return 1;
+}
+
+int
+cmd_update(int argc, char **argv, struct mpd_connection *conn)
+{
+	return update_db(argc, argv, conn, false);
+}
+
+int
+cmd_rescan(int argc, char **argv, struct mpd_connection *conn)
+{
+	return update_db(argc, argv, conn, true);
 }
 
 static int

--- a/src/command.h
+++ b/src/command.h
@@ -51,6 +51,7 @@ int cmd_crossfade(int argc, char **argv, struct mpd_connection *conn);
 int cmd_mixrampdb(int argc, char **argv, struct mpd_connection *conn);
 int cmd_mixrampdelay(int argc, char **argv, struct mpd_connection *conn);
 int cmd_update(int argc, char **argv, struct mpd_connection *conn);
+int cmd_rescan(int argc, char **argv, struct mpd_connection *conn);
 int cmd_version(int argc, char **argv, struct mpd_connection *conn);
 int cmd_stats(int argc, char **argv, struct mpd_connection *conn);
 int cmd_cdprev(int argc, char **argv, struct mpd_connection *conn);

--- a/src/main.c
+++ b/src/main.c
@@ -112,6 +112,7 @@ static const struct command {
 	{"mixrampdb",   0,   1,   0,    cmd_mixrampdb,   "[<dB>]", "Set and display mixrampdb settings"},
 	{"mixrampdelay",0,   1,   0,    cmd_mixrampdelay,"[<seconds>]", "Set and display mixrampdelay settings"},
 	{"update",      0,   -1,  2,    cmd_update,      "[<path>]", "Scan music directory for updates"},
+	{"rescan",      0,   -1,  2,    cmd_rescan,      "[<path>]", "Rescan music directory (including unchanged files)"},
 	{"sticker",     2,   -1,  0,    cmd_sticker,     "<uri> <get|set|list|delete|find> [args..]", "Sticker management"},
 	{"stats",       0,   -1,  0,    cmd_stats,       "", "Display statistics about MPD"},
 	{"version",     0,   0,   0,    cmd_version,     "", "Report version of MPD"},


### PR DESCRIPTION
Currently, only the `update` command is available to mpc. In case the user wants to rescan the whole database including unchanged files the `rescan` command exists, but cannot be used using `mpc`. This fixes the issue. Most code is shared with the `update` command implementation.