### PR TITLE
New command seekthrough -- seek through playlist

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -164,6 +164,14 @@ Player Commands
    If a :samp:`+` or :samp:`-` is used, the seek is done relative to
    the current song position. Absolute seeking by default.
 
+:command:`seekthrough [+\-][<HH:MM:SS>]` - Seeks by hour,
+   minute or seconds, hours or minutes can be omitted, relatively to
+   the current position. If the duration exceeds the limit of the
+   current song, the seek command procedes to seek through the playlist
+   until the duration is reached.
+   If a :samp:`+` is used, the seek is forward. If a :samp:`-` is
+   used, the seek is backward. Forward seeking by default.
+
 :command:`stop` - Stops playing.
 
 :command:`toggle` - Toggles between play and pause. If stopped starts

--- a/src/command.c
+++ b/src/command.c
@@ -220,6 +220,175 @@ cmd_searchplay(gcc_unused int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_seek_through(gcc_unused int argc, gcc_unused char **argv,
+	 struct mpd_connection *conn)
+{
+	char * arg = argv[0];
+
+	int seekchange;
+	int rel = 0;
+
+	/* Detect +/- if exists point to the next char */
+	if (*arg == '+')
+		rel = 1;
+	else if (*arg == '-')
+		rel = -1;
+
+	if (rel == 0)
+		rel = 1;
+        else
+		++arg;
+
+	int total_secs;
+
+	if (strchr(arg, ':') != NULL) {
+		int hr = 0;
+		int min = 0;
+		int sec = 0;
+
+		/* Take the seconds off the end of arg */
+		char *sec_ptr = strrchr(arg, ':');
+
+		/* Remove ':' and move the pointer one byte up */
+		*sec_ptr = '\0';
+		++sec_ptr;
+
+		/* If hour is in the argument, else just point to the arg */
+		char *min_ptr = strrchr(arg, ':');
+		if (min_ptr != NULL) {
+
+			/* Remove ':' and move the pointer one byte up */
+			*min_ptr = '\0';
+			++min_ptr;
+
+			/* If the argument still exists, it's the hour  */
+			if (arg != NULL) {
+				char *hr_ptr = arg;
+				char *test;
+				hr = strtol(hr_ptr, &test, 10);
+
+				if (*test != '\0' ||
+					(rel == 1 && hr < 0))
+					DIE("\"%s\" is not a positive number\n", sec_ptr);
+			}
+		} else {
+			min_ptr = arg;
+		}
+
+		/* Change the pointers to a integer  */
+		char *test;
+		sec = strtol(sec_ptr, &test, 10);
+
+		if (*test != '\0' || (rel == 1 && sec < 0))
+			DIE("\"%s\" is not a positive number\n", sec_ptr);
+
+		min = strtol( min_ptr, &test, 10 );
+
+		if( *test != '\0' || (rel == 1 && min < 0 ))
+			DIE("\"%s\" is not a positive number\n", min_ptr);
+
+		/* If mins exist, check secs. If hrs exist, check mins  */
+		if (min && strlen(sec_ptr) != 2)
+			DIE("\"%s\" is not two digits\n", sec_ptr);
+		else if (hr && strlen(min_ptr) != 2)
+			DIE("\"%s\" is not two digits\n", min_ptr);
+
+		/* Finally, make sure they're not above 60 if higher unit exists */
+		if (min && sec > 60)
+			DIE("\"%s\" is greater than 60\n", sec_ptr);
+		else if (hr && min > 60 )
+			DIE("\"%s\" is greater than 60\n", min_ptr);
+
+		total_secs = (hr * 3600) + (min * 60) + sec;
+
+	} else {
+
+		/* absolute seek (in seconds) */
+		char *test;
+		total_secs = strtol(arg, &test, 10); /* get the # of seconds */
+
+		if (*test != '\0' || (rel == 1 && total_secs < 0))
+			DIE("\"%s\" is not a positive number\n", arg);
+	}
+
+	seekchange = total_secs;
+
+	int k = 0;
+	bool is_playing = 1;
+	bool is_paused = 1;
+	bool initial_is_paused = 0;
+	while ((is_playing || is_paused) && k++ < 100) {
+		struct mpd_status *status;
+		status = getStatus(conn);
+		int track_duration = mpd_status_get_total_time(status);
+		int track_elapsed = mpd_status_get_elapsed_time(status);
+		is_playing = mpd_status_get_state(status) == MPD_STATE_PLAY;
+		is_paused = mpd_status_get_state(status) == MPD_STATE_PAUSE;
+		int songpos = mpd_status_get_song_pos(status);
+		mpd_status_free(status);
+		if (k == 1)
+			initial_is_paused = is_paused;
+
+		if ((rel >= 0) && (seekchange >= track_duration - track_elapsed)) {
+			seekchange -= track_duration - track_elapsed;
+			if (!mpd_run_next(conn))
+				printErrorAndExit(conn);
+			/* checking if end of playlist has been reached */
+			status = getStatus(conn);
+			track_duration = mpd_status_get_total_time(status);
+			is_playing = mpd_status_get_state(status) == MPD_STATE_PLAY;
+			mpd_status_free(status);
+			if (!is_playing)
+				return -127;
+		}
+
+		if ((rel < 0) && (seekchange > track_elapsed)) {
+			seekchange -= track_elapsed;
+			if (!mpd_run_previous(conn))
+				printErrorAndExit(conn);
+			status = getStatus(conn);
+			if (mpd_status_get_song_pos(status) == songpos) {
+				seekchange = 0;
+				break;
+			}
+			track_duration = mpd_status_get_total_time(status);
+			mpd_status_free(status);
+                        seekchange -= track_duration;
+			if (seekchange < 0) {
+				rel = 1;
+				seekchange = -seekchange;
+			}
+		}
+		if ((rel >= 0) && (seekchange < track_duration - track_elapsed))
+			break;
+		if ((rel < 0) && (seekchange <= track_elapsed))
+			break;
+	}
+        if (initial_is_paused)
+                cmd_pause(0, NULL, conn);
+
+	if (seekchange == 0)
+		return 1;
+
+	char buffer[32];
+
+	/* This detects +/- and is necessary due to the parsing of HH:MM:SS numbers*/
+	if (rel < 0)
+		seekchange = -seekchange;
+
+	if (rel)
+		snprintf(buffer, sizeof(buffer), "%+d", seekchange);
+	else
+		snprintf(buffer, sizeof(buffer), "%d", seekchange);
+
+	if (!mpd_send_command(conn, "seekcur", buffer, NULL) ||
+	    !mpd_response_finish(conn))
+		printErrorAndExit(conn);
+
+	return 1;
+}
+
+int
 cmd_seek(gcc_unused int argc, gcc_unused char **argv,
 	 struct mpd_connection *conn)
 {

--- a/src/command.h
+++ b/src/command.h
@@ -33,6 +33,7 @@ int cmd_pause(int argc, char **argv, struct mpd_connection *conn);
 int cmd_pause_if_playing(int argc, char **argv, struct mpd_connection *conn);
 int cmd_stop(int argc, char **argv, struct mpd_connection *conn);
 int cmd_seek(int argc, char **argv, struct mpd_connection *conn);
+int cmd_seek_through(int argc, char **argv, struct mpd_connection *conn);
 int cmd_clearerror(int argc, char **argv, struct mpd_connection *conn);
 int cmd_move(int argc, char **argv, struct mpd_connection *conn);
 int cmd_listall(int argc, char **argv, struct mpd_connection *conn);

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ static const struct command {
 	{"cdprev",      0,   0,   0,    cmd_cdprev,      "", "Compact disk player-like previous command"},
 	{"stop",        0,   0,   0,    cmd_stop,        "", "Stop playback"},
 	{"seek",        1,   1,   0,    cmd_seek,        "[+-][HH:MM:SS]|<0-100>%", "Seeks to the specified position"},
+	{"seekthrough", 1,   1,   0,    cmd_seek_through, "[+-][HH:MM:SS]", "Seeks by an amount of time within the song and playlist"},
 	{"clear",       0,   0,   0,    cmd_clear,       "", "Clear the queue"},
 	{"outputs",     0,   0,   0,    cmd_outputs,     "", "Show the current outputs"},
 	{"enable",      1,   -1,  0,    cmd_enable,      "[only] <output # or name> [...]", "Enable output(s)"},


### PR DESCRIPTION
This enables to seek forward or backward by an arbitrary duration relative to the current position in the track. If the duration stays within the limit of the current track, the result is the same as command seek. If the duration exceeds the limits of the current track (forward or backward), it continues seeking into next/previous songs until accumulating the exact duration asked, or reaching the end/beginning of the playlist.

Durations in percentages or absolute position, which exist for command seek, do not make sense for this command.

If music was initially paused, the paused status is restored in the end.

An arbitrary limit of 100 iterations is set to avoid an infinite loops (could happen if duration of the song is very short, rounding to zero, and player is set to repeat).
