### PR TITLE
Avoid underlines in generated manpage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,7 +42,7 @@ Options
  %title%            Title file tag
  %track%            Track file tag
  %time%             Duration of file
- %file%             Path of file, relative to MPD's `music_directory` variable
+ %file%             Path of file, relative to MPD's ``music_directory`` variable
  %position%         Queue track number
  %id%               Queue track id number
  %prio%             Priority in the (random) queue.
@@ -50,10 +50,10 @@ Options
  %mdate%            Date of last file modification
  ================== ======================================================
 
- The `[]` operator is used to group output such that if no metadata
- delimiters are found or matched between `[` and `]`, then none of the
- characters between `[` and `]` are output.  `&` and `|` are logical
- operators for and and or.  `#` is used to escape characters.  Some
+ The ``[]`` operator is used to group output such that if no metadata
+ delimiters are found or matched between ``[`` and ``]``, then none of the
+ characters between ``[`` and ``]`` are output.  ``&`` and ``|`` are logical
+ operators for and and or.  ``#`` is used to escape characters.  Some
  useful examples for format are: ":samp:`%file%`" and
  ":samp:`[[%artist% - ]%title%]|[%file%]`".  This command also takes
  the following defined escape sequences:


### PR DESCRIPTION
This change modifies certain inline markup to fence it as ` ``code`` `, instead of using the <code>\`default role\`</code>. When generated as a man page, text in the default role is underlined, which can cause readability issues on the terminal if the fenced text includes underscores or characters like square brackets, both of which overlap with the underline. As ` ``code`` ` the fenced text will be boldfaced instead of underlined.

(Screenshots of `man mpc` in a Gnome Terminal session. Note the invisible underscore in the `music_directory` variable, as well as the odd formatting of the square braces due to the underline.)

![screenshot from 2018-05-22 04-16-00](https://user-images.githubusercontent.com/538020/40350235-336ef1bc-5d77-11e8-95ec-c65ba970b13a.png)
![screenshot from 2018-05-22 04-16-10](https://user-images.githubusercontent.com/538020/40350237-355bb618-5d77-11e8-8cef-dd5660e15342.png)

After this change:
![screenshot from 2018-05-22 04-26-13](https://user-images.githubusercontent.com/538020/40350621-54fbd93e-5d78-11e8-8017-dcfd48976e71.png)
![screenshot from 2018-05-22 04-26-22](https://user-images.githubusercontent.com/538020/40350622-56bb5ccc-5d78-11e8-99fb-34d7469d5d26.png)

The other option would've been to format these blocks using the `:samp:` role, but I was going by the [Sphinx documentation for that role](http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-samp) which directs:
> Within the contents, you can use curly braces to indicate a “variable” part, as in file. For example, in <code>:samp:\`print 1+{variable}\`</code>, the part `variable` would be emphasized.
>
> If you don’t need the “variable part” indication, use the standard ` ``code`` ` instead.