### PR TITLE
added numbers in front of songs when listing the current playlist with command "cmd_playlist"

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -136,3 +136,19 @@ print_filenames(struct mpd_connection *conn)
 	if (mpd_connection_get_error(conn) != MPD_ERROR_SUCCESS)
 		printErrorAndExit(conn);
 }
+
+unsigned
+find_digit_width_of_uint(const unsigned number)
+{
+	/* width derivation obtained from https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10Obvious */
+	unsigned digits =
+		(number < 10U) ? 1U :
+		(number < 100U) ? 2U :
+		(number < 1000U) ? 3U :
+		(number < 10000U) ? 4U :
+		(number < 100000U) ? 5U :
+		(number < 1000000U) ? 6U :
+		23U; /* just a very large placeholder for 64bit uint */
+
+	return digits;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -65,4 +65,7 @@ print_entity_list(struct mpd_connection *c, enum mpd_entity_type filter_type);
 void
 print_filenames(struct mpd_connection *conn);
 
+unsigned
+find_digit_width_of_uint(const unsigned number);
+
 #endif /* MPC_UTIL_H */	


### PR DESCRIPTION
this is a little update that allows a user to view incrementing numbers in front of the current playlist.
This is userful so that they can then easily jump to another song in the playlist using 
mpc play <number_of_song_to_play>

