### PR TITLE
meson: add docs switch.

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,23 +1,19 @@
-sphinx = find_program('sphinx-build', required:false)
+custom_target(
+  'HTML documentation',
+  output: 'html',
+  input: ['index.rst', 'conf.py'],
+  command: [sphinx, '-q', '-b', 'html', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@'],
+  build_by_default: true,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'doc', meson.project_name()),
+)
 
-if sphinx.found()
-  custom_target(
-    'HTML documentation',
-    output: 'html',
-    input: ['index.rst', 'conf.py'],
-    command: [sphinx, '-q', '-b', 'html', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@'],
-    build_by_default: true,
-    install: true,
-    install_dir: join_paths(get_option('datadir'), 'doc', meson.project_name()),
-  )
-
-  custom_target(
-    'Manpage documentation',
-    output: 'man',
-    input: ['index.rst', 'conf.py'],
-    command: [sphinx, '-q', '-b', 'man', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@/man1'],
-    build_by_default: true,
-    install: true,
-    install_dir: get_option('datadir'),
-  )
-endif
+custom_target(
+  'Manpage documentation',
+  output: 'man',
+  input: ['index.rst', 'conf.py'],
+  command: [sphinx, '-q', '-b', 'man', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@/man1'],
+  build_by_default: true,
+  install: true,
+  install_dir: get_option('datadir'),
+)

--- a/meson.build
+++ b/meson.build
@@ -114,4 +114,15 @@ if get_option('test')
   subdir('test')
 endif
 
-subdir('doc')
+with_docs = get_option('docs')
+sphinx = find_program('sphinx-build', required: false)
+
+if with_docs == 'auto' and sphinx.found()
+  subdir('doc')
+elif with_docs == 'true'
+  if not sphinx.found()
+	error('docs enabled but sphinx-build not found')
+  endif
+  subdir('doc')
+endif
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,7 @@ option('iconv', type: 'combo',
 option('test', type: 'boolean',
   value: false,
   description: 'Enable unit tests')
+
+option('docs', type: 'combo',
+  choices: ['true', 'false', 'auto'], value: 'auto',
+  description: 'Build documentation and manpage with Sphinx')


### PR DESCRIPTION
This PR adds.

- a docs switch that is a boolean set to true
- guards the doc subdir with the switch and make the Sphinx dependency obligatory.