### PR TITLE
Fix bash completion to work properly when set -u is in effect

### DIFF
--- a/contrib/mpc-completion.bash
+++ b/contrib/mpc-completion.bash
@@ -93,7 +93,7 @@ _mpc ()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 
 	# If there's no command, either complete options or commands
-	if [ -z "$command" ]; then
+	if [ -z "${command:-}" ]; then
 		case "$cur" in
 			--*) _mpc_long_options ;;
 			-*) COMPREPLY=() ;;


### PR DESCRIPTION
When `set -u` is in effect, i.e., expansion of undefined variables causes
an exit of the current shell, the mpc completion script seizes to work.
This change fixes the issue by guarding the access to the `command`
variable accordingly.