### PR TITLE
Fixed documentation for version command

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -377,7 +377,8 @@ Other Commands
 
    If you specify a list of events, only these events are considered.
 
-:command:`version` - Reports the version of MPD.
+:command:`version` - Reports the version of the protocol spoken, not the real
+   version of the daemon.
 
 
 Environment Variables


### PR DESCRIPTION
Be more precise regarding version command. It currently states "Reports the version of MPD" which is confusing since the command reports to protocol version and not the server version.