### PR TITLE
doc: make upload target dependency on rsync optional

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -8,17 +8,20 @@ sphinx_output = custom_target(
   install_dir: join_paths(get_option('datadir'), 'doc', meson.project_name()),
 )
 
-custom_target(
-  'upload',
-  input: sphinx_output,
-  output: 'upload',
-  build_always_stale: true,
-  command: [
-    'rsync', '-vpruz', '--delete', '@INPUT@',
-    'www.musicpd.org:/var/www/mpd/doc/mpc/',
-    '--chmod=a+rX',
-  ],
-)
+rsync = find_program('rsync', required: false)
+if rsync.found()
+  custom_target(
+    'upload',
+    input: sphinx_output,
+    output: 'upload',
+    build_always_stale: true,
+    command: [
+      rsync, '-vpruz', '--delete', '@INPUT@',
+      'www.musicpd.org:/var/www/mpd/doc/mpc/',
+      '--chmod=a+rX',
+    ],
+  )
+endif
 
 custom_target(
   'Manpage documentation',


### PR DESCRIPTION
Currently, rsync is an unconditional dependency and checked during
`meson configure`. As such, the build will fail if rsync is not installed
which is probably not what was intended here.

From the [meson documentation](https://mesonbuild.com/Reference-manual_functions.html#custom_target):

	Meson will automatically insert the appropriate dependencies on
	targets and files listed in this keyword [the command] argument.

This commit fixes the unconditional dependency on rsync with an explicit
find_program invocation with `required: false`. Also wrap the
custom_target in an if statement since it is not allowed to use
non-found external programs in `command`.