### PR TITLE
__get_long_cur removes backslashes

### DIFF
--- a/contrib/mpc-completion.bash
+++ b/contrib/mpc-completion.bash
@@ -12,8 +12,9 @@ __escape_strings_stdin () {
 
 # Read everything past the command as a single word
 # This is used for filenames (they may have spaces)
+# It also removes backslashes which occur during tab completion.
 __get_long_cur () {
-	cur="$(echo "${COMP_LINE#*$command}" | sed 's/^ *//')"
+	cur="$(echo "${COMP_LINE#*$command}" | sed 's/^ *//' | sed 's/\\//g')"  
 }
 
 # Complete boolean choices


### PR DESCRIPTION
### Bash Completion
I noticed that tab completion of filenames stopped working. I fixed the problem by hadding a text substitution to remove backslashes in __get_long_cur. It works, but I still notice an issue with using quoted strings, as opposed to escaped strings. I don't know the code, but wanted to solve the problem well enough for my own use at the moment.