### PR TITLE
Fix mpc status ''

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1140,7 +1140,10 @@ cmd_status(int argc, char **argv, struct mpd_connection *conn)
 			print_status(conn);
 		} else if (argc == 1) {
 			struct mpd_status *status = getStatus(conn);
-			printf("%s\n", format_status(status, argv[0]));
+			char* current_status = format_status(status, argv[0]);
+			if (current_status) {
+				printf("%s\n", format_status(status, argv[0]));
+			}
 		}
 	}
 	return 0;


### PR DESCRIPTION
Currently when calling mpc status with a empty string argument, the
format_object2 returns a NULL string, which leads to a segmentation fault when
the status gets printed. The implemented fix adds a check before printing the
returned status from format_song. Other callings of format_object2 seem to not
be affected by this behaviour.

Signed-off-by: shirenn <shirenn@crans.org>