### PR TITLE
Add new options for the 'mpc status' command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.35 (not yet released)
 * fix null pointer dereference on bad status format
+* add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -438,6 +438,12 @@ Other Commands
    %repeat%           Current status of repeat mode. 'on' or 'off'
    %single%           Current status of single mode. 'on', 'once', or 'off'
    %consume%          Current status of consume mode. 'on' or 'off'
+   %kbitrate%         The bit rate in kbps for the current song.
+   %audioformat%      The audio format which MPD is currently playing as 'samplerate:bits:channels'.
+   %samplerate%       The sample rate in Hz extracted from the current MPD audio format.
+   %bits%             The number of significant bits per sample size extracted from the current MPD audio format.
+   %channels%         The number of channels extracted from the current MPD audio format.
+
    ================== ======================================================
 
 :command:`version` - Reports the version of the protocol spoken, not the real

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -432,7 +432,7 @@ Other Commands
    %percenttime%      The percentage of time elapsed for the current song.
    %songpos%          The position of the current song within the playlist.
    %length%           The number of songs within the playlist
-   %state%            Either 'playing' or 'paused'
+   %state%            Either 'playing', 'paused' or 'stopped'
    %volume%           The current volume spaced out to 4 characters including a percent sign
    %random%           Current status of random mode. 'on' or 'off'
    %repeat%           Current status of repeat mode. 'on' or 'off'

--- a/src/status_format.c
+++ b/src/status_format.c
@@ -75,8 +75,12 @@ status_value(const struct mpd_status *status, const char *name)
 	} else if (strcmp(name, "state") == 0) {
 		if (mpd_status_get_state(status) == MPD_STATE_PLAY) {
 			return "playing";
-		} else {
+		} else if (mpd_status_get_state(status) == MPD_STATE_PAUSE) {
 			return "paused";
+		} else if (mpd_status_get_state(status) == MPD_STATE_STOP) {
+			return "stopped";
+		} else {
+			return "n/a";
 		}
 	} else if (strcmp(name, "volume") == 0) {
 		sprintf(buffer, "%3i%c", mpd_status_get_volume(status), '%');

--- a/src/status_format.c
+++ b/src/status_format.c
@@ -110,6 +110,36 @@ status_value(const struct mpd_status *status, const char *name)
 		} else {
 		    return "off";
 		}
+	} else if (strcmp(name, "kbitrate") == 0) {
+		sprintf(buffer, "%d", mpd_status_get_kbit_rate(status));
+	} else if (strcmp(name, "audioformat") == 0) {
+		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
+		if (af) {
+			snprintf(buffer, sizeof(buffer), "%uHz/%ubits/%u", af->sample_rate, af->bits, af->channels);
+		} else {
+			return "n/a";
+		}
+	} else if (strcmp(name, "audiosamplerate") == 0) {
+		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
+		if (af) {
+			sprintf(buffer, "%u", af->sample_rate);
+		} else {
+			return "n/a";
+		}
+	} else if (strcmp(name, "audiobits") == 0) {
+		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
+		if (af) {
+			sprintf(buffer, "%u", af->bits);
+		} else {
+			return "n/a";
+		}
+	} else if (strcmp(name, "audiochannels") == 0) {
+		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
+		if (af) {
+			sprintf(buffer, "%u", af->channels);
+		} else {
+			return "n/a";
+		}
 	}
 	else { return NULL; }
 	return buffer;

--- a/src/status_format.c
+++ b/src/status_format.c
@@ -80,7 +80,7 @@ status_value(const struct mpd_status *status, const char *name)
 		} else if (mpd_status_get_state(status) == MPD_STATE_STOP) {
 			return "stopped";
 		} else {
-			return "n/a";
+			return NULL;
 		}
 	} else if (strcmp(name, "volume") == 0) {
 		sprintf(buffer, "%3i%c", mpd_status_get_volume(status), '%');

--- a/src/status_format.c
+++ b/src/status_format.c
@@ -111,34 +111,44 @@ status_value(const struct mpd_status *status, const char *name)
 		    return "off";
 		}
 	} else if (strcmp(name, "kbitrate") == 0) {
-		sprintf(buffer, "%d", mpd_status_get_kbit_rate(status));
+		sprintf(buffer, "%u", mpd_status_get_kbit_rate(status));
 	} else if (strcmp(name, "audioformat") == 0) {
 		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
-		if (af) {
-			snprintf(buffer, sizeof(buffer), "%uHz/%ubits/%u", af->sample_rate, af->bits, af->channels);
+		if (af != NULL) {
+			if (af->bits == MPD_SAMPLE_FORMAT_FLOAT)
+				snprintf(buffer, sizeof(buffer), "%u:f:%u", af->sample_rate, af->channels);
+			else if (af->bits == MPD_SAMPLE_FORMAT_DSD)
+				snprintf(buffer, sizeof(buffer), "%u:dsd:%u", af->sample_rate, af->channels);
+			else
+				snprintf(buffer, sizeof(buffer), "%u:%u:%u", af->sample_rate, af->bits, af->channels);
 		} else {
-			return "n/a";
+			return NULL;
 		}
-	} else if (strcmp(name, "audiosamplerate") == 0) {
+	} else if (strcmp(name, "samplerate") == 0) {
 		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
-		if (af) {
+		if (af != NULL) {
 			sprintf(buffer, "%u", af->sample_rate);
 		} else {
-			return "n/a";
+			return NULL;
 		}
-	} else if (strcmp(name, "audiobits") == 0) {
+	} else if (strcmp(name, "bits") == 0) {
 		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
-		if (af) {
-			sprintf(buffer, "%u", af->bits);
+		if (af != NULL) {
+			if (af->bits == MPD_SAMPLE_FORMAT_FLOAT)
+				strcpy(buffer, "f");
+			else if (af->bits == MPD_SAMPLE_FORMAT_DSD)
+				strcpy(buffer, "dsd");
+			else
+				sprintf(buffer, "%u", af->bits);
 		} else {
-			return "n/a";
+			return NULL;
 		}
-	} else if (strcmp(name, "audiochannels") == 0) {
+	} else if (strcmp(name, "channels") == 0) {
 		const struct mpd_audio_format *af = mpd_status_get_audio_format(status);
-		if (af) {
+		if (af != NULL) {
 			sprintf(buffer, "%u", af->channels);
 		} else {
-			return "n/a";
+			return NULL;
 		}
 	}
 	else { return NULL; }


### PR DESCRIPTION
Hi,

I'd like to share new options I have added to the 'mpc status' command:

1/ mpc status '%state%' now returns 'stopped' if the MPD server is stopped

2/ mpc status '%kbitrate% %audioformat% %audiochannels% %audiobits% %audiosamplerate%' now returns full details on the audio streams (or 'n/a' if not available)

Thanks in advance for considering these (small) contributions.

Eric