### PR TITLE
add command 'lsdirs'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
 * fix null pointer dereference on bad status format
 * add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 * the "%state%" option of the "status" command now returns "stopped" when the MPD server is stopped
+* add command "lsdirs"
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -254,6 +254,10 @@ Database Commands
    ``directory``. If no ``directory`` is specified, lists all files in
    music directory.
 
+:command:`lsdirs [<directory>]` - List subdirectories of
+   ``directory``. If no ``directory`` is specified, lists subdirectories
+   in music directory.
+
 :command:`search <type> <query> [<type> <query>]...` - Searches for
    substrings in song tags.  Any number of tag type and query
    combinations can be specified.  Possible tag types are: artist,

--- a/src/command.c
+++ b/src/command.c
@@ -740,6 +740,15 @@ cmd_lsplaylists(int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_lsdirs(int argc, char **argv, struct mpd_connection *conn)
+{
+	for (int i = 0; i < argc; i++)
+		strip_trailing_slash(argv[i]);
+
+	return ls_entity(argc, argv, conn, MPD_ENTITY_TYPE_DIRECTORY);
+}
+
+int
 cmd_load(int argc, char **argv, struct mpd_connection *conn)
 {
 	const bool range = options.range.start > 0 ||

--- a/src/command.h
+++ b/src/command.h
@@ -40,6 +40,7 @@ int cmd_move(int argc, char **argv, struct mpd_connection *conn);
 int cmd_listall(int argc, char **argv, struct mpd_connection *conn);
 int cmd_ls(int argc, char **argv, struct mpd_connection *conn);
 int cmd_lsplaylists(int argc, char **argv, struct mpd_connection *conn);
+int cmd_lsdirs(int argc, char **argv, struct mpd_connection *conn);
 int cmd_load(int argc, char **argv, struct mpd_connection *conn);
 int cmd_list(int argc, char **argv, struct mpd_connection *conn);
 int cmd_save(int argc, char **argv, struct mpd_connection *conn);

--- a/src/main.c
+++ b/src/main.c
@@ -90,6 +90,7 @@ static const struct command {
 	{"loadtab",          1,  1, 0, cmd_loadtab,          "<directory>", NULL}, /* loadtab, lstab, and tab used for completion-scripting only */
 	{"ls",               0, -1, 2, cmd_ls,               "[<directory>]", "List the contents of <directory>"},
 	{"lsplaylists",      0, -1, 2, cmd_lsplaylists,      "", "List currently available playlists"},
+	{"lsdirs",           0, -1, 2, cmd_lsdirs,           "[<directory>]", "List subdirectories of <directory>"},
 	{"lstab",            1,  1, 0, cmd_lstab,            "<directory>", NULL},
 	{"makepart",         1, -1, 0, cmd_partitionmake,    "<name> ...", "Create partition(s)"},
 	{"mixrampdb",        0,  1, 0, cmd_mixrampdb,        "[<dB>]", "Set and display mixrampdb settings"},


### PR DESCRIPTION
Hi,
I would like to share a new command that could be useful : "lsdirs". "lsdirs" lists only subdirectories of the given directories (or of the whole music directory if no argument is given).
Thanks in advance for any comment !
Eric