### PR TITLE
Add 'addplaylist' and 'delplaylist' commands

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 * fix null pointer dereference on bad status format
 * add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 * the "%state%" option of the "status" command now returns "stopped" when the MPD server is stopped
-* add commands "lsdirs", "addplaylist", "delplaylist", "moveplaylist", "renplaylist"
+* add commands "lsdirs", "addplaylist", "delplaylist", "moveplaylist", "renplaylist", "clearplaylist"
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 * fix null pointer dereference on bad status format
 * add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 * the "%state%" option of the "status" command now returns "stopped" when the MPD server is stopped
-* add commands "lsdirs", "addplaylist", "delplaylist", "moveplaylist"
+* add commands "lsdirs", "addplaylist", "delplaylist", "moveplaylist", "renplaylist"
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 * fix null pointer dereference on bad status format
 * add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 * the "%state%" option of the "status" command now returns "stopped" when the MPD server is stopped
-* add commands "lsdirs", "addplaylist", "delplaylist"
+* add commands "lsdirs", "addplaylist", "delplaylist", "moveplaylist"
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 * fix null pointer dereference on bad status format
 * add "%kbitrate%", "%audioformat%", "%samplerate%", "%bits%" and "%channels%" options to the "status" command
 * the "%state%" option of the "status" command now returns "stopped" when the MPD server is stopped
-* add command "lsdirs"
+* add commands "lsdirs", "addplaylist", "delplaylist"
 
 0.34 (2021/11/30)
 * add commands "albumart", "readpicture"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -244,7 +244,8 @@ Playlist Commands
 :command:`save <file>` - Saves playlist as <file>.
 
 :command:`addplaylist <playlist> <file>` - Adds a song from the music database to the
-   playlist. Can also read input from pipes.
+   playlist. The playlist will be created if it does not exist.
+   Can also read input from pipes.
 
 :command:`delplaylist <playlist> <songpos>` - Removes the song at given position from the playlist. Can
    also read input from pipes.
@@ -253,6 +254,8 @@ Playlist Commands
    to the <to> position in the playlist.
 
 :command:`renplaylist <playlist> <new playlist>` - Rename a playlist.
+
+:command:`clearplaylist <playlist>` - Clear the playlist name (i.e. truncate playlist.m3u).
 
 Database Commands
 ^^^^^^^^^^^^^^^^^

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -249,6 +249,9 @@ Playlist Commands
 :command:`delplaylist <playlist> <songpos>` - Removes the song at given position from the playlist. Can
    also read input from pipes.
 
+:command:`moveplaylist <playlist> <from> <to>` - Moves the song at given <from> position 
+   to the <to> position in the playlist.
+
 Database Commands
 ^^^^^^^^^^^^^^^^^
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -243,6 +243,11 @@ Playlist Commands
 
 :command:`save <file>` - Saves playlist as <file>.
 
+:command:`addplaylist <playlist> <file>` - Adds a song from the music database to the
+   playlist. Can also read input from pipes.
+
+:command:`delplaylist <playlist> <songpos>` - Removes the song at given position from the playlist. Can
+   also read input from pipes.
 
 Database Commands
 ^^^^^^^^^^^^^^^^^

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -252,6 +252,8 @@ Playlist Commands
 :command:`moveplaylist <playlist> <from> <to>` - Moves the song at given <from> position 
    to the <to> position in the playlist.
 
+:command:`renplaylist <playlist> <new playlist>` - Rename a playlist.
+
 Database Commands
 ^^^^^^^^^^^^^^^^^
 

--- a/src/args.h
+++ b/src/args.h
@@ -33,6 +33,9 @@ struct int_value_change {
 int
 stdinToArgArray(char ***array);
 
+int
+stdinAndPreambleToArgArray(char ***array, char *);
+
 void
 free_pipe_array(unsigned max, char **array);
 
@@ -40,11 +43,21 @@ gcc_pure
 bool
 contains_absolute_path(unsigned argc, char **argv);
 
+gcc_pure
+bool
+contains_absolute_path_from(unsigned argc, char **argv, unsigned from);
+
 void
 strip_trailing_slash(char *s);
 
 int
 get_boolean(const char *arg);
+
+/**
+ * @return true on success
+ */
+bool
+parse_unsigned(const char *s, unsigned *value_r);
 
 /**
  * @return true on success

--- a/src/command.c
+++ b/src/command.c
@@ -570,6 +570,28 @@ cmd_move(gcc_unused int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_moveplaylist(gcc_unused int argc, char **argv, struct mpd_connection *conn)
+{
+	const char* playlist = argv[0];
+
+	int from;
+	if (!parse_int(argv[1], &from) || from <= 0)
+		DIE("\"%s\" is not a positive integer\n", argv[1]);
+
+	int to;
+	if (!parse_int(argv[2], &to) || to <= 0)
+		DIE("\"%s\" is not a positive integer\n", argv[2]);
+
+	/* users type in 1-based numbers, mpd uses 0-based */
+	--from;
+	--to;
+
+	if (!mpd_run_playlist_move(conn, playlist, from, to))
+		printErrorAndExit(conn);
+	return 0;
+}
+
+int
 cmd_listall(int argc, char **argv, struct mpd_connection *conn)
 {
 	const char * listall = "";

--- a/src/command.c
+++ b/src/command.c
@@ -837,6 +837,19 @@ cmd_delplaylist(int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_renplaylist(int argc, char **argv, struct mpd_connection *conn)
+{
+	(void)argc; // silence warning about unused argument
+	const char* playlist = argv[0];
+	const char* newplaylist = argv[1];
+
+	if (!mpd_run_rename(conn, playlist, newplaylist))
+		printErrorAndExit(conn);
+
+	return 0;
+}
+
+int
 cmd_load(int argc, char **argv, struct mpd_connection *conn)
 {
 	const bool range = options.range.start > 0 ||

--- a/src/command.c
+++ b/src/command.c
@@ -850,6 +850,18 @@ cmd_renplaylist(int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_clearplaylist(int argc, char **argv, struct mpd_connection *conn)
+{
+	(void)argc; // silence warning about unused argument
+	const char* playlist = argv[0];
+
+	if (!mpd_run_playlist_clear(conn, playlist))
+		printErrorAndExit(conn);
+
+	return 0;
+}
+
+int
 cmd_load(int argc, char **argv, struct mpd_connection *conn)
 {
 	const bool range = options.range.start > 0 ||

--- a/src/command.h
+++ b/src/command.h
@@ -41,6 +41,8 @@ int cmd_listall(int argc, char **argv, struct mpd_connection *conn);
 int cmd_ls(int argc, char **argv, struct mpd_connection *conn);
 int cmd_lsplaylists(int argc, char **argv, struct mpd_connection *conn);
 int cmd_lsdirs(int argc, char **argv, struct mpd_connection *conn);
+int cmd_addplaylist(int argc, char **argv, struct mpd_connection *conn);
+int cmd_delplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_load(int argc, char **argv, struct mpd_connection *conn);
 int cmd_list(int argc, char **argv, struct mpd_connection *conn);
 int cmd_save(int argc, char **argv, struct mpd_connection *conn);

--- a/src/command.h
+++ b/src/command.h
@@ -45,6 +45,7 @@ int cmd_lsdirs(int argc, char **argv, struct mpd_connection *conn);
 int cmd_addplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_delplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_renplaylist(int argc, char **argv, struct mpd_connection *conn);
+int cmd_clearplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_load(int argc, char **argv, struct mpd_connection *conn);
 int cmd_list(int argc, char **argv, struct mpd_connection *conn);
 int cmd_save(int argc, char **argv, struct mpd_connection *conn);

--- a/src/command.h
+++ b/src/command.h
@@ -37,6 +37,7 @@ int cmd_seek(int argc, char **argv, struct mpd_connection *conn);
 int cmd_seek_through(int argc, char **argv, struct mpd_connection *conn);
 int cmd_clearerror(int argc, char **argv, struct mpd_connection *conn);
 int cmd_move(int argc, char **argv, struct mpd_connection *conn);
+int cmd_moveplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_listall(int argc, char **argv, struct mpd_connection *conn);
 int cmd_ls(int argc, char **argv, struct mpd_connection *conn);
 int cmd_lsplaylists(int argc, char **argv, struct mpd_connection *conn);

--- a/src/command.h
+++ b/src/command.h
@@ -44,6 +44,7 @@ int cmd_lsplaylists(int argc, char **argv, struct mpd_connection *conn);
 int cmd_lsdirs(int argc, char **argv, struct mpd_connection *conn);
 int cmd_addplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_delplaylist(int argc, char **argv, struct mpd_connection *conn);
+int cmd_renplaylist(int argc, char **argv, struct mpd_connection *conn);
 int cmd_load(int argc, char **argv, struct mpd_connection *conn);
 int cmd_list(int argc, char **argv, struct mpd_connection *conn);
 int cmd_save(int argc, char **argv, struct mpd_connection *conn);

--- a/src/main.c
+++ b/src/main.c
@@ -116,6 +116,7 @@ static const struct command {
 	{"queued",	         0,  0, 0, cmd_queued,           "", "Show the next queued song"},
 	{"random",           0,  1, 0, cmd_random,           "<on|off>", "Toggle random mode, or specify state"},
 	{"readpicture",      1, 1, 0,  cmd_readpicture,      "<uri>", "Download a picture from the given song and write to stdout." },
+	{"renplaylist",      2,  2, 0, cmd_renplaylist,      "<file> <newfile>", "Rename a playlist"},
 	{"repeat",           0,  1, 0, cmd_repeat,           "<on|off>", "Toggle repeat mode, or specify state"},
 	{"replaygain",       0, -1, 0, cmd_replaygain,       "[off|track|album]", "Set or display the replay gain mode" },
 	{"rescan",           0, -1, 2, cmd_rescan,           "[<path>]", "Rescan music directory (including unchanged files)"},

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,7 @@ static const struct command {
 	int pipe;             /**
 	                       * 1: implicit pipe read, `-' optional as argv[2]
 	                       * 2: explicit pipe read, `-' needed as argv[2]
+						   * 3: implicit pipe read, `-' optional as argv[3]
 	                       */
 	cmdhandler handler;
 	const char *usage;
@@ -65,6 +66,7 @@ static const struct command {
 } mpc_table [] = {
 	/* command,     min, max, pipe, handler,         usage, help */
 	{"add",              0, -1, 1, cmd_add,              "<uri>", "Add a song to the queue"},
+	{"addplaylist",      2, -1, 3, cmd_addplaylist,      "<file> <uri> ...", "Add a song to the playlist"},
 	{"albumart",         1,  1, 0, cmd_albumart,         "<uri>", "Download album art for the given song and write to stdout." },
 	{"cdprev",           0,  0, 0, cmd_cdprev,           "", "Compact disk player-like previous command"},
 	{"channels",         0,  0, 0, cmd_channels,         "", "List the channels that other clients have subscribed to." },
@@ -76,6 +78,7 @@ static const struct command {
 	{"current",          0,  0, 0, cmd_current,          "", "Show the currently playing song"},
 	{"del",              0, -1, 1, cmd_del,              "<position>", "Remove a song from the queue"},
 	{"delpart",          1, -1, 0, cmd_partitiondelete,  "<name> ...", "Delete partition(s)"},
+	{"delplaylist",      1, -1, 3, cmd_delplaylist,      "<file> <position> ...", "Remove a song from the playlist"},
 	{"disable",          1, -1, 0, cmd_disable,          "[only] <output # or name> [...]", "Disable output(s)"},
 	{"enable",           1, -1, 0, cmd_enable,           "[only] <output # or name> [...]", "Enable output(s)"},
 	{"find",             1, -1, 0, cmd_find,             "<type> <query>", "Find a song (exact match)"},
@@ -255,6 +258,11 @@ check_args(const struct command *command, int * argc, char ** argv)
 				       0 == strcmp(argv[2],STDIN_SYMBOL)))){
 		*argc = stdinToArgArray(&array);
 		pipe_array_used = true;
+
+	} else if (command->pipe == 3 && ((*argc == 3) || ((*argc == 4) && !strcmp(argv[3], STDIN_SYMBOL)))) {
+		*argc = stdinAndPreambleToArgArray(&array, argv[2]);
+		pipe_array_used = true;
+
 	} else {
 		*argc -= 2;
 		array = malloc( (*argc * (sizeof(char *))));

--- a/src/main.c
+++ b/src/main.c
@@ -72,6 +72,7 @@ static const struct command {
 	{"channels",         0,  0, 0, cmd_channels,         "", "List the channels that other clients have subscribed to." },
 	{"clear",            0,  0, 0, cmd_clear,            "", "Clear the queue"},
 	{"clearerror",       0,  0, 0, cmd_clearerror,       "", "Clear the current error"},
+	{"clearplaylist",    1,  1, 0, cmd_clearplaylist,    "<file>", "Clear the playlist"},
 	{"consume",          0,  1, 0, cmd_consume,          "<on|off>", "Toggle consume mode, or specify state"},
 	{"crop",             0,  0, 0, cmd_crop,             "", "Remove all but the currently playing song"},
 	{"crossfade",        0,  1, 0, cmd_crossfade,        "[<seconds>]", "Set and display crossfade settings"},

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,7 @@ static const struct command {
 	{"move",             2,  2, 0, cmd_move,             "<from> <to>", "Move song in queue"},
 	{"moveoutput",       1,  1, 0, cmd_moveoutput,       "<output # or name>", "Move output to partition (see -a)"},
 	{"mv",               2,  2, 0, cmd_move,             "<from> <to>", NULL},
+	{"moveplaylist",     3,  3, 0, cmd_moveplaylist,     "<file> <from> <to>", "Move song in playlist"},
 	{"next",             0,  0, 0, cmd_next,             "", "Play the next song in the queue"},
 	{"outputs",          0,  0, 0, cmd_outputs,          "", "Show the current outputs"},
 	{"outputset",        2,  2, 0, cmd_outputset,        "<output # or name> <name>=<value>", "Set output attributes"},


### PR DESCRIPTION
Hi,
I would like to share 2 new mpc commands:
- `addplaylist <playlist> <file>`: add a file to a playlist
- `delplaylist <playlist> <position>`: remove the song at position from the playlist

NB : these 2 commands are using a new 'pipe' format descriptor (3) to allow the `<playlist>` argument to be added to the stdin arguments when used in a pipe statement...

Thanks in advance for any comment!
Eric