### PR TITLE
Add mpc status %currenttimems%

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -454,6 +454,7 @@ Other Commands
    ================== ======================================================
    %totaltime%        The total duration of the song.
    %currenttime%      The time that the client is currently at.
+   %currenttimems%    The time that the client is currently at, in milliseconds.
    %percenttime%      The percentage of time elapsed for the current song.
    %songpos%          The position of the current song within the playlist.
    %length%           The number of songs within the playlist

--- a/src/status_format.c
+++ b/src/status_format.c
@@ -50,6 +50,9 @@ status_value(const struct mpd_status *status, const char *name)
 	} else if (strcmp(name, "length") == 0) {
 		unsigned length = mpd_status_get_queue_length(status);
 		snprintf(buffer, sizeof(buffer), "%i", length);
+	} else if (strcmp(name, "currenttimems") == 0) {
+		unsigned elapsed_ms = mpd_status_get_elapsed_ms(status);
+		snprintf(buffer, sizeof(buffer), "%u", elapsed_ms);
 	} else if (strcmp(name, "currenttime") == 0) {
 		unsigned elasped = mpd_status_get_elapsed_time(status);
 		snprintf(buffer, sizeof(buffer), "%u:%02u",


### PR DESCRIPTION
I'm making a script to help add lyric timings in manually and want to get a more precise current time elapsed than just minute+second.