### PR TITLE
add command 'tags'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 0.36 (not yet released)
+* add command "tags"
 
 0.35 (2023/12/21)
 * fix null pointer dereference on bad status format

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -312,6 +312,8 @@ Database Commands
 
      mpc list album group artist
 
+:command:`tags` - display all MPD tags known by the mpc client
+
 :command:`stats` - Displays statistics about MPD.
 
 :command:`update [\-\-wait] [<path>]` - Scans for updated files in the

--- a/src/command.c
+++ b/src/command.c
@@ -871,6 +871,21 @@ cmd_load(int argc, char **argv, struct mpd_connection *conn)
 }
 
 int
+cmd_tags(gcc_unused int argc, gcc_unused char **argv, gcc_unused struct mpd_connection *conn)
+{
+	const char *name = NULL;
+
+	for (unsigned i = 0; i < MPD_TAG_COUNT; i++) {
+		name = mpd_tag_name(i);
+		if (name != NULL) {
+			printf("%s\n", name);
+		}
+	}
+	
+	return 0;
+}
+
+int
 cmd_list(int argc, char **argv, struct mpd_connection *conn)
 {
 	const char *name = argv[0];

--- a/src/command.h
+++ b/src/command.h
@@ -66,4 +66,7 @@ cmd_waitmessage(int argc, char **argv, struct mpd_connection *conn);
 int
 cmd_subscribe(int argc, char **argv, struct mpd_connection *conn);
 
+int
+cmd_tags(int argc, char **argv, struct mpd_connection *conn);
+
 #endif /* COMMAND_H */

--- a/src/main.c
+++ b/src/main.c
@@ -120,6 +120,7 @@ static const struct command {
 	{"stop",             0,  0, 0, cmd_stop,             "", "Stop playback"},
 	{"subscribe",        1,  1, 0, cmd_subscribe,        "<channel>", "Subscribe to the specified channel and continuously receive messages." },
 	{"tab",              1,  1, 0, cmd_tab,              "<path>", NULL},
+	{"tags",             0,  0, 0, cmd_tags,             "", "Display all MPD tags known by the mpc client" },
 	{"toggle",           0,  0, 0, cmd_toggle,           "", "Toggles Play/Pause, plays if stopped"},
 	{"toggleoutput",     1, -1, 0, cmd_toggle_output,    "<output # or name> [...]", "Toggle output(s)"},
 	{"unmount",          1,  1, 0, cmd_unmount,          "<mount-path>", "Remove a mount." },


### PR DESCRIPTION
Hi all,

I would like to share a new mpc command : 'tags'.

This basic command displays all the MPD tags known by the current mpc client.

Thanks in advance for any feedback !

Happy new year's eve to everyone.
Eric
