### PR TITLE
Displaying tags that can have multiple values

### DIFF
--- a/test/test_format.c
+++ b/test/test_format.c
@@ -125,6 +125,24 @@ START_TEST(test_escape)
 }
 END_TEST
 
+START_TEST(test_multi_artist)
+{
+	struct mpd_song *song = construct_song(default_file,
+			      "Artist", "Foo",
+			      "Artist", "Bar",
+			      "Artist", "Baz",
+			      "Title", "Collab Track",
+			      NULL);
+
+	// Expect multiple artists separated by ", "
+	assert_format(song, "%artist%", "Foo, Bar, Baz");
+	assert_format(song, "%title%", "Collab Track");
+	assert_format(song, "%artist% - %title%", "Foo, Bar, Baz - Collab Track");
+
+	mpd_song_free(song);
+}
+END_TEST
+
 static Suite *
 create_suite(void)
 {
@@ -136,6 +154,7 @@ create_suite(void)
 	tcase_add_test(tc_core, test_fallback);
 	tcase_add_test(tc_core, test_default);
 	tcase_add_test(tc_core, test_escape);
+	tcase_add_test(tc_core, test_multi_artist);
 	suite_add_tcase(s, tc_core);
 	return s;
 }


### PR DESCRIPTION
Add functionality to display e.g. multiple artists.
Separation is done with ` || `, in line with the style that other popular mpc clients use (ncmpcpp, rmpc).

Example output of `mpc status` for a song with two artists using this fix:
```
Froukje || S10 - Ik Haat Hem Voor Jou
[playing] #4/4   1:27/2:35 (56%)
volume:100%   repeat: off   random: off   single: off   consume: off
```

Fixes #120.
