### PR TITLE
ADD --force flag to cmd_save

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -84,6 +84,10 @@ Options
 
  Wait for operation to finish (e.g. database update).
 
+.. option:: -F, --force
+
+ Force certain operations (e.g. overwriting playlist while saving).
+
 .. option:: --range=[START]:[END]
 
  Operate on a range (e.g. when loading a playlist).  START is the
@@ -250,7 +254,8 @@ Playlist Commands
 
 :command:`rm <file>` - Deletes a specific playlist.
 
-:command:`save <file>` - Saves playlist as <file>.
+:command:`save [--force] <file>` - Saves playlist as <file>. With
+   :option:`--force`, overwrites the playlist if it already exists.
 
 :command:`addplaylist <playlist> <file>` - Adds a song from the music database to the
    playlist. The playlist will be created if it does not exist.

--- a/src/command.c
+++ b/src/command.c
@@ -28,7 +28,6 @@ SIMPLE_CMD(cmd_prev, mpd_run_previous, 1)
 SIMPLE_CMD(cmd_stop, mpd_run_stop, 1)
 SIMPLE_CMD(cmd_clearerror, mpd_run_clearerror, 1)
 
-SIMPLE_ONEARG_CMD(cmd_save, mpd_run_save, 0)
 SIMPLE_ONEARG_CMD(cmd_rm, mpd_run_rm, 0)
 
 /**
@@ -1373,6 +1372,19 @@ cmd_partitiondelete(int argc, char **argv, struct mpd_connection *conn) {
 
 	if (!mpd_command_list_end(conn) || !mpd_response_finish(conn)) {
 		printErrorAndExit(conn);
+	}
+	return 0;
+}
+
+int
+cmd_save(gcc_unused int argc, char **argv, struct mpd_connection *conn)
+{
+	if (options.force) {
+		if (!mpd_send_save_queue(conn, charset_to_utf8(argv[0]), MPD_QUEUE_SAVE_MODE_REPLACE))
+			printErrorAndExit(conn);
+	} else {
+		if (!mpd_run_save(conn, charset_to_utf8(argv[0])))
+			printErrorAndExit(conn);
 	}
 	return 0;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -48,6 +48,7 @@ static const struct OptionDef option_table[] = {
 	{ 'w', "wait", NULL, "Wait for operation to finish (e.g. database update)" },
 	{ 'r', "range", "[<start>]:[<end>]", "Operate on a range (e.g. when loading a playlist)" },
 	{ 'a', "partition", "<name>", "Operate on partition <name> instead" },
+	{ 'F', "force", NULL, "Force some operations (like saving playlist)" },
 	{ OPTION_WITH_PRIO, "with-prio", NULL, "Show only songs that have a non-zero priority" },
 };
 
@@ -162,6 +163,10 @@ handle_option(int c, const char *arg)
 
 	case 'w':
 		options.wait = true;
+		break;
+
+	case 'F':
+		options.force = true;
 		break;
 
 	case 'r':

--- a/src/options.h
+++ b/src/options.h
@@ -28,6 +28,7 @@ struct Options {
 
 	int verbosity; // 0 for quiet, 1 for default, 2 for verbose
 	bool wait;
+	bool force;
 
 	bool custom_format;
 


### PR DESCRIPTION
Allow to replace an existing playlist with the `mpc replace PLAYLIST` command, calling `mpd_send_save_queue` with the `MPD_QUEUE_SAVE_MODE_REPLACE` flag.

Hi 👋

I was tired of having to do `mpc rm PLAYLIST && mpc save PLAYLIST`, so I implemented `mpc replace PLAYLIST`. 

That… may be solving a first world problem. 😅

I don't know if you're interested in that or if you would consider it feature creep. I'm cool either way, I have the patch managed by Portage so I can patch my local copy of mpc, so no big deal if you think this patch doesn't belong in the main tree - just submitting it in case you think it does.