### PR TITLE
chore: doc format fixing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ You need:
 - libmpdclient 2.18
 - `Meson 0.47 <http://mesonbuild.com/>`__ and `Ninja <https://ninja-build.org/>`__
 
-Run ``meson``:
+Run ``meson``::
 
  meson . output
 


### PR DESCRIPTION
There is a bit of malformed formatting on the shell command of `meson`, this PR is for fixing that.